### PR TITLE
Fix #10 by adding the install command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ scratch/
 
 # Ansible
 .ansible/
+
+.DS_Store
+drives.yaml

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -1,0 +1,20 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+func NewInstallCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "install",
+		Short: "Install software in the environment",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+
+	cmd.AddCommand(
+		NewInstallLabCmd(),
+	)
+
+	return cmd
+}

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -4,11 +4,12 @@ import "github.com/spf13/cobra"
 
 func NewInstallCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "install",
-		Short: "Install software in the environment",
-		Args:  cobra.ExactArgs(1),
+		Use:                   "install",
+		Short:                 "Install software in the environment",
+		DisableFlagsInUseLine: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return nil
+			// Show help message if no subcommand is provided
+			return cmd.Help()
 		},
 	}
 

--- a/cmd/install_lab.go
+++ b/cmd/install_lab.go
@@ -24,17 +24,20 @@ func NewInstallLabCmd() *cobra.Command {
 	opts := InstallLabOpts{}
 
 	cmd := &cobra.Command{
-		Use:   "lab",
+		Use:   "lab LAB_NAME",
 		Short: "Install software in a lab",
-		Args:  cobra.ExactArgs(1),
+		Long:  "Install software in a lab by running Ansible playbook",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 {
+				return fmt.Errorf("lab name is required")
+			}
 			return installLab(args[0], opts)
 		},
 	}
 
 	cmd.Flags().StringVarP(&opts.Inventory, "inventory", "i", "", "path to the inventory file")
-	cmd.Flags().StringVar(&opts.Playbook, "playbook", "site.yml", "path to the playbook file")
-	cmd.Flags().BoolVarP(&opts.CreateInventory, "create-inventory", "c", false, "create the inventory file")
+	cmd.Flags().StringVarP(&opts.Playbook, "playbook", "p", "site.yml", "path to the playbook file")
+	//	cmd.Flags().BoolVarP(&opts.CreateInventory, "create-inventory", "c", false, "create the inventory file")
 
 	return cmd
 }

--- a/cmd/install_lab.go
+++ b/cmd/install_lab.go
@@ -1,0 +1,87 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pavelanni/storctl/internal/config"
+	"github.com/pavelanni/storctl/internal/lab"
+	"github.com/pavelanni/storctl/internal/provider"
+)
+
+type InstallLabOpts struct {
+	LabName         string
+	Inventory       string
+	Playbook        string
+	CreateInventory bool
+}
+
+func NewInstallLabCmd() *cobra.Command {
+	opts := InstallLabOpts{}
+
+	cmd := &cobra.Command{
+		Use:   "lab",
+		Short: "Install software in a lab",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return installLab(args[0], opts)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.Inventory, "inventory", "i", "", "path to the inventory file")
+	cmd.Flags().StringVar(&opts.Playbook, "playbook", "site.yml", "path to the playbook file")
+	cmd.Flags().BoolVarP(&opts.CreateInventory, "create-inventory", "c", false, "create the inventory file")
+
+	return cmd
+}
+
+func installLab(labName string, opts InstallLabOpts) error {
+	if opts.Inventory == "" {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("error getting home directory: %w", err)
+		}
+		opts.Inventory = filepath.Join(homeDir,
+			config.DefaultConfigDir,
+			config.DefaultAnsibleDir,
+			labName+"-inventory.json")
+	}
+	inventory := lab.Inventory{}
+	data, err := os.ReadFile(opts.Inventory)
+	if err != nil {
+		return fmt.Errorf("error reading inventory file: %w", err)
+	}
+	if err := json.Unmarshal(data, &inventory); err != nil {
+		return fmt.Errorf("error unmarshalling inventory file: %w", err)
+	}
+	if inventory.All.Vars["provider"] == nil {
+		inventory.All.Vars["provider"] = config.DefaultLocalProvider
+	}
+	providerSvc, err := provider.NewProvider(*cfg, inventory.All.Vars["provider"].(string))
+	if err != nil {
+		return fmt.Errorf("error creating provider: %w", err)
+	}
+	labSvc, err := lab.NewManager(providerSvc, cfg)
+	if err != nil {
+		return fmt.Errorf("error creating lab manager: %w", err)
+	}
+	lab, err := labSvc.Get(labName) // get from the storage
+	if err != nil {
+		return fmt.Errorf("error getting lab: %w", err)
+	}
+	if opts.Playbook != "" {
+		lab.Spec.Ansible.Playbook = opts.Playbook
+	}
+	if opts.Inventory != "" {
+		lab.Spec.Ansible.Inventory = opts.Inventory
+	}
+	err = labSvc.RunAnsiblePlaybook(lab)
+	if err != nil {
+		return fmt.Errorf("error running ansible playbook: %w", err)
+	}
+	return nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -72,6 +72,7 @@ func NewRootCmd() *cobra.Command {
 		NewCreateCmd(),
 		NewSyncCmd(),
 		NewVersionCmd(),
+		NewInstallCmd(),
 	)
 
 	return cmd

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -167,10 +167,12 @@ type SSHKeyExistsStatus struct {
 }
 
 type AnsibleSpec struct {
-	ConfigFile string `json:"configFile"`
-	Inventory  string `json:"inventory"`
-	Playbook   string `json:"playbook"`
-	User       string `json:"user"`
+	ConfigFile        string `json:"configFile"`
+	Inventory         string `json:"inventory"`
+	InventoryFullPath string `json:"inventoryFullPath"`
+	Playbook          string `json:"playbook"`
+	PlaybookFullPath  string `json:"playbookFullPath"`
+	User              string `json:"user"`
 }
 
 // Resource represents the common fields for all resources


### PR DESCRIPTION
Now you can run `storctl install lab` and it will re-run the Ansible playbook configured for this lab or run a different playbook specified via `--playbook`. It uses the default inventory created for this lab and stored in the database, but you can use a different inventory file by using the `--inventory` flag.

I added `--skip-install` and `--skip-dns` flags to the `create lab` command. Just in case you want just install the VMs.

Also, I added a bit smarter operations with the playbook and inventory files: if it's a full path it's used as-is. If not, the default paths are added.